### PR TITLE
PP Source: config.py modified, now var_weights and data_weights are w…

### DIFF
--- a/pyropython/config.py
+++ b/pyropython/config.py
@@ -270,15 +270,15 @@ def read_model(input):
     for key, (etime, edata) in exp_data.items():
         if key in data_weights:
             entry = data_weights[key]
-            if isinstance(dict, entry):
+            if isinstance(entry, dict):
                 wtime, weights = read_data(**entry)
-            elif isinstance(list, entry):
+            elif isinstance(entry, list):
                 wtime, weights = zip(*entry)
             else:
                 warnings.warn(("Problem with weights for variable %s."
                                "Weigths set to one.") % key)
                 wtime = etime
-                weights = ones(1, len(etime))
+                weights = ones(len(etime))
         else:
             wtime = etime
             weights = ones(len(etime))


### PR DESCRIPTION
…orking.

The source code had some errors: isinstance(list,entry) had the arguments
in the wrong order, correct one is (entry,list).  And there was also
a command ones(1,len(etime) => ones(len(etime) should it be.  These were
not catched, because the PP examples never used these parts of the source
code. Why? Well, all the example config files (and the html documentation)
has a line "obejctive:". It should read "objective:", or course...